### PR TITLE
Fix local deployment

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .jekyll-metadata
 Gemfile.lock
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,5 @@ gem "minima"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll_remote_include", "~> 0.1.5"
+  gem "jekyll_remote_include"
 end


### PR DESCRIPTION
The required version of `jekyll_remote_include` was incompatible
with the latest jekyll. The point is, we don't have to require a
specific version of that plugin anymore, the latest one works fine.

Also, let's not install gems into the system but rather install
them into `vendor` directory - for many obvious reasons, but mainly
to avoid conflicts between requirements for running multiple jekyll
sites on one dev system.