### PR TITLE
Fixing bundle conflicts caused by jekyll-remote-include

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,16 @@ gem "jekyll", ">= 3.6.3"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima"
 
+# Workaround
+# https://talk.jekyllrb.com/t/load-error-cannot-load-such-file-webrick/5417/7
+gem "webrick"
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll_remote_include"
+  gem "jekyll-remote-include"
   gem "kramdown-parser-gfm"
 end

--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ As it is apparent from posts filename extension `.md`, they are formatted in [Ma
 
 Don't get scared by the fact that you should run something locally. You don't have to. However, if you want to see, how the post will look once we release it, run this page locally. It is no more than
 
+    sudo dnf install ruby-devel g++
     bundle install
     bundle exec jekyll serve --incremental --drafts

--- a/_config.yml
+++ b/_config.yml
@@ -30,5 +30,5 @@ disqus:
 markdown: kramdown
 theme: minima
 
-gems:
-  - jekyll_remote_include
+plugins:
+  - jekyll-remote-include


### PR DESCRIPTION
    Resolving dependencies...
    Bundler found conflicting requirements for the Ruby version:
      In Gemfile:
        jekyll_remote_include was resolved to 0.2.0, which depends on
          Ruby (~> 2.0)

      Current Ruby version:
        Ruby (= 3.1.2)

Do we even use the remote plugin anymore?