### PR TITLE
Add link to a Copr segment on Fedora Podcast episode 55

### DIFF
--- a/_posts/2026-06-10-copr-at-fedora-podcast.md
+++ b/_posts/2026-06-10-copr-at-fedora-podcast.md
@@ -1,0 +1,7 @@
+---
+title: Copr at Fedora Podcast
+author: Jakub Kadlčík
+layout: post
+external_url: https://www.youtube.com/watch?v=m59OdC3BLp0&t=313s
+type: video
+---


### PR DESCRIPTION
The link is timestamped and goes directly to the segment about Copr https://www.youtube.com/watch?v=m59OdC3BLp0&t=313s